### PR TITLE
Use "annis" instead of "annis4_internal" as namespace

### DIFF
--- a/graphannis-api/src/main/java/org/corpus_tools/graphannis/QueryToJSON.java
+++ b/graphannis-api/src/main/java/org/corpus_tools/graphannis/QueryToJSON.java
@@ -44,7 +44,6 @@ import annis.sqlgen.model.Sibling;
 import java.util.LinkedList;
 import org.corpus_tools.annis.ql.parser.AnnisParserAntlr;
 import org.corpus_tools.annis.ql.parser.QueryData;
-import org.corpus_tools.annis.ql.parser.SemanticValidator;
 
 /**
  *

--- a/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
+++ b/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import org.bytedeco.javacpp.annotation.StdString;
 import org.corpus_tools.salt.SALT_TYPE;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SDominanceRelation;
@@ -44,7 +43,7 @@ import org.slf4j.LoggerFactory;
 public class SaltImport
 {
 
-  public static final String ANNIS_NS = "annis4_internal";
+  public static final String ANNIS_NS = "annis";
 
   private static final Logger log = LoggerFactory.getLogger(SaltImport.class);
 

--- a/src/benchmarks/parallelbenchmark.cpp
+++ b/src/benchmarks/parallelbenchmark.cpp
@@ -130,8 +130,8 @@ class GUMFixture : public celero::TestFixture
           std::shared_ptr<Query> result = std::make_shared<Query>(db, config);
 
           result->addNode(std::make_shared<RegexAnnoSearch>(db, "pos", "NN.*"));
-          result->addNode(std::make_shared<ExactAnnoValueSearch>(db, "annis4_internal", "tok", "used"));
-          result->addNode(std::make_shared<ExactAnnoValueSearch>(db, "annis4_internal", "tok", "to"));
+          result->addNode(std::make_shared<ExactAnnoValueSearch>(db, annis_ns, annis_tok, "used"));
+          result->addNode(std::make_shared<ExactAnnoValueSearch>(db, annis_ns, annis_tok, "to"));
 
           result->addOperator(std::make_shared<Precedence>(db, db.edges), 0, 1);
           result->addOperator(std::make_shared<Precedence>(db, db.edges), 1, 2);

--- a/src/lib/annis/types.h
+++ b/src/lib/annis/types.h
@@ -12,7 +12,7 @@ namespace annis
 {
   typedef std::uint32_t nodeid_t;
 
-  const std::string annis_ns = "annis4_internal";
+  const std::string annis_ns = "annis";
   const std::string annis_node_name = "node_name";
   const std::string annis_tok = "tok";
 


### PR DESCRIPTION
graphANNIS specific labels have a special namespace. This used to be "annis4_internal" but since we don't make this dependent on a version number of annis it should be changed. Also, using "annis" as a namespace would make the this in sync with the relANNIS implementation which uses this special namespace e.g. for adding a documen to the metadata.