### PR TITLE
Node names should include the document name (and the URL specific stuff) when imported from Salt.

### DIFF
--- a/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
+++ b/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
@@ -15,6 +15,7 @@
  */
 package org.corpus_tools.graphannis;
 
+import com.google.common.base.Joiner;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -193,23 +194,41 @@ public class SaltImport
     
   }
   
+  private static String documentName(SNode node)
+  {
+    if(node != null)
+    {
+      String[] segments = node.getPath().segments();
+      if (segments.length > 0)
+      {
+        return segments[segments.length - 1];
+      }
+    }
+    
+    return null;
+  }
+  
+  private static String documentPath(SNode node)
+  {
+    if(node != null)
+    {
+      String[] segments = node.getPath().segments();
+      if (segments.length > 0)
+      {
+        return Joiner.on("/").join(segments);
+      }
+    }
+    
+    return null;
+  }
+  
   
   private static String nodeName(SNode node)
   {
     if(node != null)
     {
-      // if this node is attached to a document, include the document name in the node name to make it unique
-      String prefix = "";
-      SGraph graph = node.getGraph();
-      if(graph instanceof SDocumentGraph)
-      {
-        SDocument doc = ((SDocumentGraph) graph).getDocument();
-        if(doc != null)
-        {
-          prefix = doc + "/#";
-        }
-      }
-      return prefix + node.getPath().fragment();
+      String path = documentPath(node);
+      return path == null ? "#" + node.getPath().fragment() : path + "#" + node.getPath().fragment() ;
     }
     else
     {
@@ -267,10 +286,10 @@ public class SaltImport
       }
 
       // add the document name if given
-      String[] segments = n.getPath().segments();
-      if (segments.length > 0)
+      String doc = documentName(n);
+      if(doc != null)
       {
-        updateList.addNodeLabel(name, ANNIS_NS, "document", segments[segments.length - 1]);
+        updateList.addNodeLabel(name, ANNIS_NS, "document", doc);
       }
     }
   }

--- a/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
+++ b/graphannis-api/src/main/java/org/corpus_tools/graphannis/SaltImport.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.corpus_tools.salt.SALT_TYPE;
+import org.corpus_tools.salt.common.SDocument;
 import org.corpus_tools.salt.common.SDocumentGraph;
 import org.corpus_tools.salt.common.SDominanceRelation;
 import org.corpus_tools.salt.common.SPointingRelation;
@@ -29,6 +30,7 @@ import org.corpus_tools.salt.common.STextualDS;
 import org.corpus_tools.salt.common.STextualRelation;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SAnnotation;
+import org.corpus_tools.salt.core.SGraph;
 import org.corpus_tools.salt.core.SLayer;
 import org.corpus_tools.salt.core.SNode;
 import org.corpus_tools.salt.core.SRelation;
@@ -196,7 +198,18 @@ public class SaltImport
   {
     if(node != null)
     {
-      return node.getPath().fragment();
+      // if this node is attached to a document, include the document name in the node name to make it unique
+      String prefix = "";
+      SGraph graph = node.getGraph();
+      if(graph instanceof SDocumentGraph)
+      {
+        SDocument doc = ((SDocumentGraph) graph).getDocument();
+        if(doc != null)
+        {
+          prefix = doc + "/#";
+        }
+      }
+      return prefix + node.getPath().fragment();
     }
     else
     {

--- a/src/lib/annis/api/corpusstoragemanager.cpp
+++ b/src/lib/annis/api/corpusstoragemanager.cpp
@@ -171,8 +171,8 @@ std::vector<std::string> CorpusStorageManager::find(std::vector<std::string> cor
                 << "::";
             }
 
-            // we expect that the document name is included in the node name
-            matchDesc << "salt:/" << c << "/" << db.getNodeName(n.node);
+            // we expect that the document path including the corpus name is included in the node name
+            matchDesc << "salt:/" << db.getNodeName(n.node);
 
             if(i < m.size()-1)
             {

--- a/src/lib/annis/api/corpusstoragemanager.cpp
+++ b/src/lib/annis/api/corpusstoragemanager.cpp
@@ -171,8 +171,8 @@ std::vector<std::string> CorpusStorageManager::find(std::vector<std::string> cor
                 << "::";
             }
 
-            matchDesc << "salt:/" << c << "/";
-            matchDesc << db.getNodeDocument(n.node) << "/#" << db.getNodeName(n.node);
+            // we expect that the document name is included in the node name
+            matchDesc << "salt:/" << c << "/" << db.getNodeName(n.node);
 
             if(i < m.size()-1)
             {

--- a/src/lib/annis/db.cpp
+++ b/src/lib/annis/db.cpp
@@ -200,7 +200,7 @@ bool DB::loadRelANNIS(string dirPath)
     }
   }
   
-  map<uint32_t, std::uint32_t> corpusIDToName;
+  map<uint32_t, std::string> corpusIDToName;
   if(loadRelANNISCorpusTab(dirPath, corpusIDToName, isANNIS33Format) == false)
   {
     return false;
@@ -260,7 +260,7 @@ bool DB::loadRelANNIS(string dirPath)
 }
 
 
-bool DB::loadRelANNISCorpusTab(string dirPath, map<uint32_t, std::uint32_t>& corpusIDToName,
+bool DB::loadRelANNISCorpusTab(string dirPath, map<uint32_t, std::string>& corpusIDToName,
   bool isANNIS33Format)
 {
   string corpusTabPath = dirPath + "/corpus" + (isANNIS33Format ? ".annis" : ".tab");
@@ -279,13 +279,12 @@ bool DB::loadRelANNISCorpusTab(string dirPath, map<uint32_t, std::uint32_t>& cor
   while((line = Helper::nextCSV(in)).size() > 0)
   {
     std::uint32_t corpusID = Helper::uint32FromString(line[0]);
-    std::uint32_t nameID = strings.add(line[1]);
-    corpusIDToName[corpusID] = nameID;
+    corpusIDToName[corpusID] = line[1];
   }
   return true;
 }
 
-bool DB::loadRelANNISNode(string dirPath, map<uint32_t, std::uint32_t>& corpusIDToName,
+bool DB::loadRelANNISNode(string dirPath, map<uint32_t, std::string>& corpusIDToName,
   bool isANNIS33Format)
 {
   typedef multimap<TextProperty, uint32_t>::const_iterator TextPropIt;
@@ -333,9 +332,11 @@ bool DB::loadRelANNISNode(string dirPath, map<uint32_t, std::uint32_t>& corpusID
       uint32_t textID = Helper::uint32FromString(line[1]);
       uint32_t corpusID = Helper::uint32FromString(line[2]);
 
+      std::string docName = corpusIDToName[corpusID];
+
       Annotation nodeNameAnno;
       nodeNameAnno.ns = strings.add(annis_ns);
-      nodeNameAnno.name = strings.add(annis_node_name);
+      nodeNameAnno.name =  strings.add(annis_node_name);
       nodeNameAnno.val = strings.add(line[4]);
       annoList.push_back(std::pair<NodeAnnotationKey, uint32_t>({nodeNr, nodeNameAnno.name, nodeNameAnno.ns }, nodeNameAnno.val));
 
@@ -343,7 +344,7 @@ bool DB::loadRelANNISNode(string dirPath, map<uint32_t, std::uint32_t>& corpusID
       Annotation documentNameAnno;
       documentNameAnno.ns = strings.add(annis_ns);
       documentNameAnno.name = strings.add("document");
-      documentNameAnno.val = corpusIDToName[corpusID];
+      documentNameAnno.val = strings.add(docName);
       annoList.push_back(std::pair<NodeAnnotationKey, uint32_t>({nodeNr, documentNameAnno.name, documentNameAnno.ns }, documentNameAnno.val));
 
       TextProperty left;

--- a/src/lib/annis/db.h
+++ b/src/lib/annis/db.h
@@ -132,9 +132,9 @@ private:
   std::uint32_t annisNodeNameStringID;
 
 private:
-  bool loadRelANNISCorpusTab(std::string dirPath, std::map<std::uint32_t, std::uint32_t>& corpusIDToName,
+  bool loadRelANNISCorpusTab(std::string dirPath, std::map<std::uint32_t, std::string> &corpusIDToName,
     bool isANNIS33Format);
-  bool loadRelANNISNode(std::string dirPath, std::map<std::uint32_t, std::uint32_t>& corpusIDToName,
+  bool loadRelANNISNode(std::string dirPath, std::map<std::uint32_t, std::string> &corpusIDToName,
     bool isANNIS33Format);
   bool loadRelANNISRank(const std::string& dirPath,
                         const std::map<uint32_t, std::shared_ptr<WriteableGraphStorage> > &componentToGS,

--- a/src/lib/annis/db.h
+++ b/src/lib/annis/db.h
@@ -132,10 +132,12 @@ private:
   std::uint32_t annisNodeNameStringID;
 
 private:
-  bool loadRelANNISCorpusTab(std::string dirPath, std::map<std::uint32_t, std::string> &corpusIDToName,
+  std::string loadRelANNISCorpusTab(std::string dirPath, std::map<std::uint32_t,
+                                    std::string> &corpusIDToName,
     bool isANNIS33Format);
   bool loadRelANNISNode(std::string dirPath, std::map<std::uint32_t, std::string> &corpusIDToName,
-    bool isANNIS33Format);
+                        std::string toplevelCorpusName,
+                        bool isANNIS33Format);
   bool loadRelANNISRank(const std::string& dirPath,
                         const std::map<uint32_t, std::shared_ptr<WriteableGraphStorage> > &componentToGS,
                         bool isANNIS33Format);

--- a/src/tests/LoadTest.h
+++ b/src/tests/LoadTest.h
@@ -75,7 +75,7 @@ TEST_F(LoadTest, NodeAnnotations) {
 
   EXPECT_STREQ(annis::annis_ns.c_str(), db.strings.str(annos[1].ns).c_str());
   EXPECT_STREQ("node_name", db.strings.str(annos[1].name).c_str());
-  EXPECT_STREQ("tok_13", db.strings.str(annos[1].val).c_str());
+  EXPECT_STREQ("pcc2/4282#tok_13", db.strings.str(annos[1].val).c_str());
 
   EXPECT_STREQ(annis::annis_ns.c_str(), db.strings.str(annos[2].ns).c_str());
   EXPECT_STREQ("document", db.strings.str(annos[2].name).c_str());


### PR DESCRIPTION
In graphANNIS it is perfectly legal to have edges between nodes from different documents. There are several places where it is assumed that node names are unique (e.g. the graph update). This is only true in Salt for nodes inside a document, but not for a complete corpus (the same in relANNIS). Thus to make the node name unique the document name has to be used as a prefix.