### PR TITLE
Optimize unbound regex annotation searches

### DIFF
--- a/src/lib/annis/annosearch/regexannosearch.cpp
+++ b/src/lib/annis/annosearch/regexannosearch.cpp
@@ -32,6 +32,7 @@ using namespace annis;
 RegexAnnoSearch::RegexAnnoSearch(const DB &db, const std::string& ns,
                                  const std::string& name, const std::string& valRegex)
   : db(db),
+    annoKeyNamespace(ns), annoKeyName(name),
     validAnnotationsInitialized(false), valRegex(valRegex),
     compiledValRegex(valRegex),
     debugDescription(ns + ":" + name + "=/" + valRegex + "/")
@@ -53,10 +54,23 @@ RegexAnnoSearch::RegexAnnoSearch(const DB &db, const std::string& ns,
   }
 }
 
+bool RegexAnnoSearch::valueMatchesAllStrings() const
+{
+  if(compiledValRegex.ok())
+  {
+    if(compiledValRegex.pattern() == ".*")
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 
 RegexAnnoSearch::RegexAnnoSearch(const DB &db,
                                  const std::string& name, const std::string& valRegex)
   : db(db),
+    annoKeyName(name),
     validAnnotationsInitialized(false), valRegex(valRegex),
     compiledValRegex(valRegex),
     debugDescription(name + "=/" + valRegex + "/")

--- a/src/lib/annis/annosearch/regexannosearch.h
+++ b/src/lib/annis/annosearch/regexannosearch.h
@@ -52,10 +52,18 @@ namespace annis
       return validAnnotations;
     }
 
-    virtual const std::set<AnnotationKey>& getValidAnnotationKeys()
+    bool valueMatchesAllStrings() const;
+
+    boost::optional<std::string> getAnnoKeyNamespace() const
     {
-      return validAnnotationKeys;
+      return annoKeyNamespace;
     }
+
+    std::string getAnnoKeyName() const
+    {
+      return annoKeyName;
+    }
+
     
     virtual bool next(Match& result) override;
     virtual void reset() override;
@@ -67,11 +75,12 @@ namespace annis
     virtual ~RegexAnnoSearch();
   private:
     const DB& db;
+
+    boost::optional<std::string> annoKeyNamespace;
+    std::string annoKeyName;
+
     std::unordered_set<Annotation> validAnnotations;
     bool validAnnotationsInitialized;
-
-    // always empty
-    std::set<AnnotationKey> validAnnotationKeys;
 
     std::string valRegex;
     RE2 compiledValRegex;

--- a/src/lib/annis/query/singlealternativequery.h
+++ b/src/lib/annis/query/singlealternativequery.h
@@ -102,6 +102,8 @@ private:
                                    const std::vector<OperatorEntry>& operators,
                                    std::map<size_t, size_t> parallelizationMapping = std::map<size_t,size_t>());
   
+  void optimizeUnboundRegex();
+
   void optimizeOperandOrder();
 
   void optimizeEdgeAnnoUsage();

--- a/src/lib/annis/wrapper.h
+++ b/src/lib/annis/wrapper.h
@@ -159,6 +159,11 @@ namespace annis
     {
       return delegate;
     }
+
+    void setDelegate(std::shared_ptr<EstimatedSearch> newDelegate)
+    {
+      delegate = newDelegate;
+    }
     
     std::int64_t guessMaxCount() const override
     {


### PR DESCRIPTION
Use the anno key search whenever the regex matches all possible strings.