### PR TITLE
Do not iterate over covered text positions but use the token index 

### DIFF
--- a/misc/convertAll.py
+++ b/misc/convertAll.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os
+from subprocess import call;
+
+for d in os.listdir('relannis/'):
+    print("Checking " + d)
+    if(os.path.isdir('relannis/' + d)):
+        print("Converting " + d)
+        call(["build/annis_runner", "import", 'relannis/' + d, 'data/' + d])
+

--- a/src/lib/annis/util/relannisloader.cpp
+++ b/src/lib/annis/util/relannisloader.cpp
@@ -180,7 +180,8 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
   map<nodeid_t, uint32_t> nodeToRight;
 
   // maps a character position to it's token
-  map<TextProperty, nodeid_t> tokenByTextPosition;
+  map<TextProperty, nodeid_t> tokenByLeftTextPos;
+  map<TextProperty, nodeid_t> tokenByRightTextPos;
 
   // maps a token node id to the token index
   map<nodeid_t, TextProperty> tokenToIndex;
@@ -282,11 +283,9 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
         textPos.segmentation = "";
         textPos.textID = textID;
         textPos.corpusID = corpusID;
-        for(uint32_t i=left.val; i <= right.val; i++)
-        {
-          textPos.val = i;
-          tokenByTextPosition.insert({textPos, nodeNr});
-        }
+
+        tokenByLeftTextPos.insert({left, nodeNr});
+        tokenByRightTextPos.insert({right, nodeNr});
 
       } // end if token
       else if(hasSegmentations)
@@ -433,8 +432,8 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
 
 
       // find left/right aligned basic token
-      nodeid_t leftAlignedToken = tokenByTextPosition[leftPos];
-      nodeid_t rightAlignedToken = tokenByTextPosition[rightPos];
+      nodeid_t leftAlignedToken = tokenByLeftTextPos[leftPos];
+      nodeid_t rightAlignedToken = tokenByRightTextPos[rightPos];
 
       TextProperty leftTokPos = tokenToIndex[leftAlignedToken];
       TextProperty rightTokPos = tokenToIndex[rightAlignedToken];

--- a/src/lib/annis/util/relannisloader.cpp
+++ b/src/lib/annis/util/relannisloader.cpp
@@ -168,7 +168,7 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
   typedef multimap<TextProperty, uint32_t>::const_iterator TextPropIt;
 
   // maps a token index to an node ID
-  map<TextProperty, uint32_t> tokenByIndex;
+  map<TextProperty, nodeid_t> tokenByIndex;
 
   // map the "left" value to the nodes it belongs to
   multimap<TextProperty, nodeid_t> leftToNode;
@@ -181,7 +181,9 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
 
   // maps a character position to it's token
   map<TextProperty, nodeid_t> tokenByTextPosition;
-  unordered_set<nodeid_t> isToken;
+
+  // maps a token node id to the token index
+  map<nodeid_t, TextProperty> tokenToIndex;
 
   map<nodeid_t, string> missingSegmentationSpan;
 
@@ -273,8 +275,8 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
         index.textID = textID;
         index.corpusID = corpusID;
 
-        isToken.insert(nodeNr);
         tokenByIndex.insert({index, nodeNr});
+        tokenToIndex.insert({nodeNr, index});
 
         TextProperty textPos;
         textPos.segmentation = "";
@@ -417,27 +419,31 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
   {
     nodeid_t n = itLeftToNode->second;
 
-    if(isToken.find(n) == isToken.end())
+    if(tokenToIndex.find(n) == tokenToIndex.end())
     {
-      TextProperty textPos;
-      textPos.segmentation = "";
-      textPos.textID = itLeftToNode->first.textID;
-      textPos.corpusID = itLeftToNode->first.corpusID;
+      TextProperty textPosTemplate;
+      textPosTemplate.segmentation = "";
+      textPosTemplate.textID = itLeftToNode->first.textID;
+      textPosTemplate.corpusID = itLeftToNode->first.corpusID;
 
-      uint32_t left = itLeftToNode->first.val;
-      uint32_t right = nodeToRight[n];
+      TextProperty leftPos = textPosTemplate;
+      TextProperty rightPos = textPosTemplate;
+      leftPos.val = itLeftToNode->first.val;
+      rightPos.val =  nodeToRight[n];
 
-      if(left == right)
+
+      // find left/right aligned basic token
+      nodeid_t leftAlignedToken = tokenByTextPosition[leftPos];
+      nodeid_t rightAlignedToken = tokenByTextPosition[rightPos];
+
+      TextProperty leftTokPos = tokenToIndex[leftAlignedToken];
+      TextProperty rightTokPos = tokenToIndex[rightAlignedToken];
+
+      TextProperty tokIdx = textPosTemplate;
+      for(uint32_t i = leftTokPos.val; i <= rightTokPos.val; i++)
       {
-        // make sure at least the initial left value is getting a covered edge even if this is an empty string
-        right++;
-      }
-
-      for(uint32_t i = left; i < right; i++)
-      {
-        // get the token that belongs to this text position
-        textPos.val = i;
-        nodeid_t tokenID = tokenByTextPosition[textPos];
+        tokIdx.val = i;
+        nodeid_t tokenID = tokenByIndex[tokIdx];
         if(n != tokenID)
         {
           gsCoverage->addEdge(Init::initEdge(n, tokenID));

--- a/src/lib/annis/util/relannisloader.cpp
+++ b/src/lib/annis/util/relannisloader.cpp
@@ -279,11 +279,6 @@ bool RelANNISLoader::loadRelANNISNode(string dirPath,
         tokenByIndex.insert({index, nodeNr});
         tokenToIndex.insert({nodeNr, index});
 
-        TextProperty textPos;
-        textPos.segmentation = "";
-        textPos.textID = textID;
-        textPos.corpusID = corpusID;
-
         tokenByLeftTextPos.insert({left, nodeNr});
         tokenByRightTextPos.insert({right, nodeNr});
 


### PR DESCRIPTION
There is currently a problem when importing corpora that have token with empty spans. Since the coverage edge generator is iterating over the left-right character position range a node covering an empty span can't find the corresponding token.

Instead, the left and right aligned token are found using the left/right text pos value but then the iteration is over the token index, not over the text character index.