### PR TITLE
Allow to load query in console from file

### DIFF
--- a/src/runner/console.cpp
+++ b/src/runner/console.cpp
@@ -22,6 +22,8 @@
 #include <thread>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/shared_lock_guard.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 #include <annis/util/helper.h>
 #include <annis/util/relannisloader.h>
@@ -124,6 +126,27 @@ bool Console::execute(const std::string &cmd, const std::vector<std::string> &ar
   }
 
   return false;
+}
+
+std::string Console::getJSON(const std::vector<std::string>& args)
+{
+  if(args.size() > 1 && args[0] == "file") {
+     boost::filesystem::ifstream stream;
+     std::vector<std::string> fileArgs(args);
+     fileArgs.erase(fileArgs.begin());
+
+      stream.open(boost::join(fileArgs, " "));
+      std::string queryJSON(
+        (std::istreambuf_iterator<char>(stream)),
+        (std::istreambuf_iterator<char>()));
+      stream.close();
+
+      return queryJSON;
+  }
+  else
+  {
+    return boost::join(args, " ");
+  }
 }
 
 void Console::import(const std::vector<std::string> &args)
@@ -235,7 +258,7 @@ void Console::count(const std::vector<std::string> &args)
   {
     if(args.size() > 0)
     {
-      std::string json = boost::join(args, " ");
+      std::string json = getJSON(args);
       std::cout << "Counting..." << std::endl;
       std::stringstream ss;
       ss << json;
@@ -270,7 +293,7 @@ void Console::find(const std::vector<std::string> &args)
   {
     if(args.size() > 0)
     {
-      std::string json = boost::join(args, " ");
+      std::string json = getJSON(args);
       std::cout << "Finding..." << std::endl;
       std::stringstream ss;
       ss << json;
@@ -384,7 +407,7 @@ void Console::plan(const std::vector<std::string> &args)
   {
     if(args.size() > 0)
     {
-      std::string json = boost::join(args, " ");
+      std::string json = getJSON(args);
       std::cout << "Planning..." << std::endl;
       std::stringstream ss;
       ss << json;

--- a/src/runner/console.h
+++ b/src/runner/console.h
@@ -57,6 +57,8 @@ private:
 
   std::shared_ptr<annis::DB> db;
   QueryConfig config;
+
+  std::string getJSON(const std::vector<std::string>& args);
 };
 
 }


### PR DESCRIPTION
This allows to use the keyword "file" followed by a space and the filename to be used instead of the JSON when performing the various operations in the console. Thus, it is possible to load complex and long JSON from files instead of squeezing it into one line. For some larger queries, it is not even possible to reliable copy the complete JSON into the command line.